### PR TITLE
Add Probe Temp Sensor to Einsy Config and M860 Macro for Probe Warm-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ printer.cfg
 resonance.cfg
 resonances.cfg
 moonraker.conf
+mainsail.cfg
 mcu.cfg
 *.rsuser
 *.suo

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ mcu.cfg
 *.userosscache
 *.sln.docstates
 .idea/
+.moonraker.conf.bkp
+.variables.cfg
 webcam.txt
 
 # User-specific files (MonoDevelop/Xamarin Studio)

--- a/Boards/Einsy/pins.cfg
+++ b/Boards/Einsy/pins.cfg
@@ -15,6 +15,7 @@ aliases:
 #  adxl345_cs_pin=PA15,
 # auto leveling
   probe_pin=PB4,
+  probe_temp_pin=PF3,
 # fans
   fan_part_cooling_pin=PH3,
   fan_toolhead_cooling_pin=PH5,

--- a/Boards/Einsy/printer_einsy.cfg
+++ b/Boards/Einsy/printer_einsy.cfg
@@ -12,6 +12,11 @@ sensor_type: TDK NTCG104LH104JT1
 min_temp: -10
 max_temp: 70
 
+[temperature_sensor Probe_temp]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: probe_temp_pin
+gcode_id:P
+
 #####################################################################
 #   Printer Type
 #####################################################################

--- a/Macros/wait_for_probe_temp_M860.cfg
+++ b/Macros/wait_for_probe_temp_M860.cfg
@@ -1,0 +1,4 @@
+[gcode_macro M860]
+gcode:
+    {% set S = params.S|default(35) %}
+    TEMPERATURE_WAIT SENSOR="temperature_sensor Probe_temp" MINIMUM={S}


### PR DESCRIPTION
Hi! I really like your config, it's working great for me on my Caribou Rel3s with an Einsy.

These are a few additions that I made so that I could use the PINDA V2's temp sensor and the M860 g-code command to wait for probe temp. Bobstro's startup sequence ([Link](https://projects.ttlexceeded.com/3dprinting_prusaslicer_start_gcode_mk3.html)) uses M860, and I've had very consistent results using it with the Prusa Marlin FW, so I wanted to keep using it on Klipper.

I also added a few config files to the .gitignore. 

Please let me know if you have any questions or concerns.

Best,
DevX8000